### PR TITLE
 Run cppcheck on a temporary file with a possibly unsaved document text

### DIFF
--- a/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
+++ b/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
@@ -141,7 +141,7 @@ public class CppcheckInspection extends LocalInspectionTool {
       }
 
       // Cppcheck error or parsing error.
-      if (lineNumber <= 0 || lineNumber >= document.getLineCount()) {
+      if (lineNumber <= 0 || lineNumber > document.getLineCount()) {
         continue;
       }
 

--- a/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
+++ b/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.psi.PsiFile;
+import com.intellij.util.DocumentUtil;
 import com.intellij.util.execution.ParametersListUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -147,19 +148,12 @@ public class CppcheckInspection extends LocalInspectionTool {
       // Document counts lines starting at 0, rather than 1 like in cppcheck.
       lineNumber -= 1;
 
-      final int lineStartOffset = document.getLineStartOffset(lineNumber);
+      final int lineStartOffset = DocumentUtil.getFirstNonSpaceCharOffset(document, lineNumber);
       final int lintEndOffset = document.getLineEndOffset(lineNumber);
-
-      // Do not highlight empty whitespace prepended to lines.
-      String line_text = document.getImmutableCharSequence().subSequence(
-        lineStartOffset, lintEndOffset).toString();
-
-      final int numberOfPrependedSpaces = line_text.length() -
-                                          line_text.replaceAll("^\\s+","").length();
 
       ProblemDescriptor problemDescriptor = manager.createProblemDescriptor(
         psiFile,
-        TextRange.create(lineStartOffset + numberOfPrependedSpaces, lintEndOffset),
+        TextRange.create(lineStartOffset, lintEndOffset),
         "cppcheck: (" + severity + ") " + errorMessage,
         severityToHighlightType(severity),
         true);


### PR DESCRIPTION
Here is the PR that hopefully fixes #14. Before the cppcheck is run, a temp file with the document contents is created, and the header search path with the original directory is prepended to mimic the normal behavior.

Unfortunately, I've had to move some things around to do it, so the diff is rather unnecessary noisy.