### PR TITLE
Fix for new CppCheck versions (>1.88)

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>com.github.johnthagen.cppcheck</id>
   <name>cppcheck</name>
-  <version>1.2.0</version>
+  <version>1.3.0a</version>
   <vendor email="johnthagen@gmail.com" url="http://github.com/johnthagen">johnthagen</vendor>
 
   <description><![CDATA[

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -74,13 +74,13 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <localInspection implementationClass="com.github.johnthagen.cppcheck.CppcheckInspection"
-                     displayName="cppcheck inspections"
+                     displayName="CppCheck Inspections"
                      groupName="cppcheck"
                      id="CppcheckInspection"
                      level="WARNING"
                      enabledByDefault="true"/>
     <applicationConfigurable instance="com.github.johnthagen.cppcheck.Configuration"
-                             displayName="cppcheck configuration"/>
+                             displayName="CppCheck Configuration"/>
   </extensions>
 
   <actions>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>com.github.johnthagen.cppcheck</id>
   <name>cppcheck</name>
-  <version>1.3.0a</version>
+  <version>1.3.0</version>
   <vendor email="johnthagen@gmail.com" url="http://github.com/johnthagen">johnthagen</vendor>
 
   <description><![CDATA[
@@ -61,6 +61,11 @@
 
   <change-notes><![CDATA[
       1.2.0 Greatly improve plugin responsiveness to changes by using virtual files to interact with cppcheck.<br/>
+    ]]>
+  </change-notes>
+
+  <change-notes><![CDATA[
+      1.3.0 Fix for new versions of CppCheck which use the --template={} option. <br/>
     ]]>
   </change-notes>
 

--- a/src/com/github/johnthagen/cppcheck/Configuration.java
+++ b/src/com/github/johnthagen/cppcheck/Configuration.java
@@ -17,14 +17,15 @@ public class Configuration implements Configurable {
   private static final String CPPCHECK_NOTE =
     "Note: C++ projects should leave --language=c++ appended to the cppcheck options to avoid some " +
     "false positives in header files due to the fact that cppcheck implicitly defaults to " +
-    "setting --language to \"c\" for .h files.";
+    "setting --language to \"c\" for .h files.\n\n" +
+    "You should not include any --template={} in the options.";
   private CppcheckConfigurationModifiedListener
     listener = new CppcheckConfigurationModifiedListener(this);
 
   static final String CONFIGURATION_KEY_CPPCHECK_PATH = "cppcheck";
   static final String CONFIGURATION_KEY_CPPCHECK_OPTIONS = "cppcheckOptions";
 
-  private static final String defaultOptions = "--enable=warning,performance,portability,style --language=c++ --template=\"[{file}:{line}]: ({severity}) {message}\"";
+  private static final String defaultOptions = "--enable=warning,performance,portability,style --language=c++";
 
   @Nls
   @Override
@@ -46,8 +47,8 @@ public class Configuration implements Configurable {
     VerticalLayout verticalLayout = new VerticalLayout(1, 2);
     jPanel.setLayout(verticalLayout);
 
-    cppcheckFilePicker = new JFilePicker("cppcheck path:", "...");
-    JLabel optionFieldLabel = new JLabel("cppcheck options (default: " + defaultOptions + "):");
+    cppcheckFilePicker = new JFilePicker("CppCheck Path:", "...");
+    JLabel optionFieldLabel = new JLabel("CppCheck Options (Default: " + defaultOptions + "):");
     cppcheckOptionsField = new JTextField(defaultOptions, 38);
 
     // The first time a user installs the plugin, save the default options in their properties.

--- a/src/com/github/johnthagen/cppcheck/Configuration.java
+++ b/src/com/github/johnthagen/cppcheck/Configuration.java
@@ -24,7 +24,7 @@ public class Configuration implements Configurable {
   static final String CONFIGURATION_KEY_CPPCHECK_PATH = "cppcheck";
   static final String CONFIGURATION_KEY_CPPCHECK_OPTIONS = "cppcheckOptions";
 
-  private static final String defaultOptions = "--enable=warning,performance,portability,style --language=c++";
+  private static final String defaultOptions = "--enable=warning,performance,portability,style --language=c++ --template=\"[{file}:{line}]: ({severity}) {message}\"";
 
   @Nls
   @Override

--- a/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
+++ b/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
@@ -168,10 +168,17 @@ public class CppcheckInspection extends LocalInspectionTool {
   private static String executeCommandOnFile(@NotNull final String command,
                                              @NotNull final String options,
                                              @NotNull final String filePath) throws ExecutionException {
+
+    if (options.contains("--template")) {
+      throw new ExecutionException("CppCheck Error: cppcheck options contains --template field. Please remove this, the plugin defines its own.");
+    }
+
     GeneralCommandLine cmd = new GeneralCommandLine()
       .withExePath(command)
       .withParameters(ParametersListUtil.parse(options))
+      .withParameters(ParametersListUtil.parse("--template=\"[{file}:{line}]: ({severity}) {message}\""))
       .withParameters("\"" + filePath + "\"");
+
     CapturingProcessHandler processHandler = new CapturingProcessHandler(cmd);
     ProgressIndicator indicator = ProgressManager.getInstance().getProgressIndicator();
     ProcessOutput output = processHandler.runProcessWithProgressIndicator(
@@ -183,11 +190,11 @@ public class CppcheckInspection extends LocalInspectionTool {
     }
 
     if (output.isTimeout()) {
-      throw new ExecutionException("cppcheck error: timeout: " + cmd.getCommandLineString());
+      throw new ExecutionException("CppCheck Error: Timeout: " + cmd.getCommandLineString());
     }
 
     if (output.getExitCode() != 0) {
-      throw new ExecutionException("cppcheck error : exitcode-" + output.getExitCode() + " : " + cmd.getCommandLineString());
+      throw new ExecutionException("CppCheck Error : Exit Code - " + output.getExitCode() + " : " + cmd.getCommandLineString());
     }
 
     return output.getStderr();

--- a/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
+++ b/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
@@ -183,11 +183,11 @@ public class CppcheckInspection extends LocalInspectionTool {
     }
 
     if (output.isTimeout()) {
-      throw new ExecutionException(command + " has timed out");
+      throw new ExecutionException("cppcheck error: timeout: " + cmd.getCommandLineString());
     }
 
     if (output.getExitCode() != 0) {
-      throw new ExecutionException(command + " has finished with exit code " + output.getExitCode());
+      throw new ExecutionException("cppcheck error : exitcode-" + output.getExitCode() + " : " + cmd.getCommandLineString());
     }
 
     return output.getStderr();


### PR DESCRIPTION
Following the CppCheck output format change in V1.88 (I think), newer versions of CppCheck will not work with this plugin due to the constant regex it uses. To solve this, the template output functionality of CppCheck was used to bring the output back into line with the output the plugin expects. 

This is a work-in-progress. I will let you know when it is ready for pull. Just thought i'd create this PR as a marker that work IS being done on this. 

Cheers for a brilliant plugin btw! 