### PR TITLE
improved reporting of execution failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Deployment.
 
 ### 1.5.1 - XXXX-XX-XX
 
+Improved reporting of execution failures. (Contribution by @firewave)
+
 ### 1.5.0 - 2020-11-01
 
 - Correctly specify minimum supported CLion version.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Deployment.
 
 ## Releases
 
+### 1.5.1 - XXXX-XX-XX
+
 ### 1.5.0 - 2020-11-01
 
 - Correctly specify minimum supported CLion version.

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -61,7 +61,7 @@
     ]]></description>
 
   <change-notes><![CDATA[
-      1.5.1 <br/>
+      1.5.1 Improved reporting of execution failures. (Contribution by @firewave)<br/>
     ]]>
   </change-notes>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>com.github.johnthagen.cppcheck</id>
   <name>cppcheck</name>
-  <version>1.5.0</version>
+  <version>1.5.1</version>
   <vendor email="johnthagen@gmail.com" url="http://github.com/johnthagen">johnthagen</vendor>
 
   <description><![CDATA[
@@ -61,8 +61,7 @@
     ]]></description>
 
   <change-notes><![CDATA[
-      1.5.0 Correctly specify minimum supported CLion version.<br/>
-      Support annotating inconclusive results in the IDE. (Contribution by @firewave)<br/>
+      1.5.1 <br/>
     ]]>
   </change-notes>
 

--- a/src/com/github/johnthagen/cppcheck/CppcheckError.java
+++ b/src/com/github/johnthagen/cppcheck/CppcheckError.java
@@ -1,0 +1,10 @@
+package com.github.johnthagen.cppcheck;
+
+import org.jetbrains.annotations.NotNull;
+
+public class CppcheckError extends Error {
+    public CppcheckError(@NotNull final String message)
+    {
+        super(message);
+    }
+}


### PR DESCRIPTION
Failures to execute cppcheck now look like this:

![image](https://user-images.githubusercontent.com/242857/97892557-71cf9f80-1d30-11eb-8a52-3be906e01835.png)
