### PR TITLE
fixed some issues with potentially non-existent files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Deployment.
 
 - Parse `--xml` output instead of text output. (Contribution by @firewave)
 - Fixed scanning of files with whitespaces in name. (Contribution by @firewave)
+- Only scan files which actually exist. (Contribution by @firewave)
 
 ### 1.5.1 - 2020-11-12
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Deployment.
 - Parse `--xml` output instead of text output. (Contribution by @firewave)
 - Fixed scanning of files with whitespaces in name. (Contribution by @firewave)
 - Only scan files which actually exist. (Contribution by @firewave)
+- Use unique file names for temporary files used for analysis. (Contribution by @firewave)
 
 ### 1.5.1 - 2020-11-12
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Deployment.
 
 ### 1.6.0 - XXXX-XX-XX
 
-Parse `--xml` output instead of text output. (Contribution by @firewave)
+- Parse `--xml` output instead of text output. (Contribution by @firewave)
+- Fixed scanning of files with whitespaces in name. (Contribution by @firewave)
 
 ### 1.5.1 - 2020-11-12
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -64,6 +64,7 @@
       - Parse --xml output instead of text output. (Contribution by @firewave)<br/>
       - Fixed scanning of files with whitespaces in name. (Contribution by @firewave)
       - Only scan files which actually exist. (Contribution by @firewave)
+      - Use unique file names for temporary files used for analysis. (Contribution by @firewave)
     ]]>
   </change-notes>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -61,7 +61,8 @@
     ]]></description>
 
   <change-notes><![CDATA[
-      Parse --xml output instead of text output. (Contribution by @firewave)<br/>
+      - Parse --xml output instead of text output. (Contribution by @firewave)<br/>
+      - Fixed scanning of files with whitespaces in name. (Contribution by @firewave)
     ]]>
   </change-notes>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -63,6 +63,7 @@
   <change-notes><![CDATA[
       - Parse --xml output instead of text output. (Contribution by @firewave)<br/>
       - Fixed scanning of files with whitespaces in name. (Contribution by @firewave)
+      - Only scan files which actually exist. (Contribution by @firewave)
     ]]>
   </change-notes>
 

--- a/src/com/github/johnthagen/cppcheck/CppCheckInspectionImpl.java
+++ b/src/com/github/johnthagen/cppcheck/CppCheckInspectionImpl.java
@@ -182,7 +182,7 @@ public class CppCheckInspectionImpl {
         final GeneralCommandLine cmd = new GeneralCommandLine()
                 .withExePath(command)
                 .withParameters(ParametersListUtil.parse(options))
-                .withParameters(ParametersListUtil.parse(filePath));
+                .withParameters(ParametersListUtil.parse("\"" + filePath + "\""));
 
         // Need to be able to get python from the system env
         if (cppcheckMisraPath != null && !cppcheckMisraPath.isEmpty()) {

--- a/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
+++ b/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.psi.PsiFile;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.xml.sax.SAXException;
@@ -55,7 +56,7 @@ public class CppcheckInspection extends LocalInspectionTool {
 
         File tempFile = null;
         try {
-            tempFile = FileUtil.createTempFile("", vFile.getName(), true);
+            tempFile = FileUtil.createTempFile(RandomStringUtils.randomAlphanumeric(8) + "_", vFile.getName(), true);
             FileUtil.writeToFile(tempFile, document.getText());
             final String cppcheckOutput =
                     CppCheckInspectionImpl.executeCommandOnFile(cppcheckPath, prependIncludeDir(cppcheckOptions, vFile),

--- a/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
+++ b/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
@@ -29,7 +29,7 @@ public class CppcheckInspection extends LocalInspectionTool {
                                          @NotNull InspectionManager manager,
                                          boolean isOnTheFly) {
         final VirtualFile vFile = file.getVirtualFile();
-        if (vFile == null || !isCFamilyFile(vFile)) {
+        if (vFile == null || !vFile.isInLocalFileSystem() || !isCFamilyFile(vFile)) {
             return ProblemDescriptor.EMPTY_ARRAY;
         }
 


### PR DESCRIPTION
The temporary file name conflict issue can happen if you have two files with the same name or (more likely) when the plugin is flooded with duplicated check requests during batch scanning.