### PR TITLE
report execution errors as global inspection errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.idea/shelf/
 /clion-cppcheck.jar
 /out

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Deployment.
 ### 1.6.3 - 20XX-XX-XX
 
 - Added `Show Cppcheck XML Output` action to show the latest XML output.
+- Report execution errors as global inspection errors.
 
 ### 1.6.2 - 2022-01-25
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -61,6 +61,7 @@
 
   <change-notes><![CDATA[
     - Added `Show Cppcheck XML Output` action to show the latest XML output.
+    - Report execution errors as global inspection errors.
     ]]>
   </change-notes>
 


### PR DESCRIPTION
Currently the execution failures are only shown as notifications. So if a file causes a failure or timeout there will be no inspection warnings shown which might indicate that it has no problems.

Using a global inspection warning will not show a `Problems` tab entry but will show an error bar indicating the error:

![image](https://user-images.githubusercontent.com/242857/228089366-ce88fc95-f874-40f8-83ba-db97cf7a1f82.png)

Additional details which cannot be shown in the problem are already available in the notification.