### PR TITLE
Display `Cppcheck Path` configuration errors as global inspection errors instead of using a (hard to spot) status bar message

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Deployment.
 - Added `Show Cppcheck XML Output` action to show the latest XML output.
 - Report execution errors as global inspection errors.
 - Display `Cppcheck Path` configuration errors as global inspection errors instead of using a (hard to spot) status bar message.
+- Display global inspection error and omit the option if the configured `MISRA Addon JSON` does not exist.
 
 ### 1.6.2 - 2022-01-25
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Deployment.
 
 - Added `Show Cppcheck XML Output` action to show the latest XML output.
 - Report execution errors as global inspection errors.
+- Display `Cppcheck Path` configuration errors as global inspection errors instead of using a (hard to spot) status bar message.
 
 ### 1.6.2 - 2022-01-25
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -25,6 +25,7 @@
   <change-notes><![CDATA[
     - Added `Show Cppcheck XML Output` action to show the latest XML output.
     - Report execution errors as global inspection errors.
+    - Display `Cppcheck Path` configuration errors as global inspection errors instead of using a (hard to spot) status bar message.
     ]]>
   </change-notes>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -26,6 +26,7 @@
     - Added `Show Cppcheck XML Output` action to show the latest XML output.
     - Report execution errors as global inspection errors.
     - Display `Cppcheck Path` configuration errors as global inspection errors instead of using a (hard to spot) status bar message.
+    - Display global inspection error and omit the option if the configured `MISRA Addon JSON` does not exist.
     ]]>
   </change-notes>
 

--- a/src/com/github/johnthagen/cppcheck/CppCheckInspectionImpl.java
+++ b/src/com/github/johnthagen/cppcheck/CppCheckInspectionImpl.java
@@ -210,12 +210,12 @@ class CppCheckInspectionImpl {
     private static final int TIMEOUT_MS = 60 * 1000;
 
     public static String executeCommandOnFile(@NotNull final VirtualFile vFile,
-                                              @NotNull final String command,
+                                              @NotNull final File command,
                                               @NotNull final String options,
                                               @NotNull final File filePath,
                                               final String cppcheckMisraPath) throws CppcheckError, ExecutionException {
         final GeneralCommandLine cmd = new GeneralCommandLine()
-                .withExePath(command)
+                .withExePath(command.toString())
                 .withParameters(ParametersListUtil.parse(options))
                 .withParameters(ParametersListUtil.parse("\"" + filePath.getAbsolutePath() + "\""));
 

--- a/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
+++ b/src/com/github/johnthagen/cppcheck/CppcheckInspection.java
@@ -27,6 +27,17 @@ import java.util.List;
 class CppcheckInspection extends LocalInspectionTool {
     final static Path LATEST_RESULT_FILE = Paths.get(FileUtil.getTempDirectory(), "clion-cppcheck-latest.xml");
 
+    private static ProblemDescriptor createProblemDescriptor(@NotNull final PsiFile file,
+                                                             @NotNull final InspectionManager manager,
+                                                             @NotNull final String msg) {
+        return manager.createProblemDescriptor(
+                file,
+                (TextRange)null,
+                msg,
+                ProblemHighlightType.GENERIC_ERROR,
+                true);
+    }
+
     @Nullable
     @Override
     public ProblemDescriptor[] checkFile(@NotNull final PsiFile file,
@@ -44,23 +55,13 @@ class CppcheckInspection extends LocalInspectionTool {
 
         final String cppcheckPath = Properties.get(Configuration.CONFIGURATION_KEY_CPPCHECK_PATH);
         if (cppcheckPath == null || cppcheckPath.isEmpty()) {
-            final ProblemDescriptor problemDescriptor = manager.createProblemDescriptor(
-                    file,
-                    (TextRange)null,
-                    "Please set 'Cppcheck Path' in the 'Cppcheck Configuration'.",
-                    ProblemHighlightType.GENERIC_ERROR,
-                    true);
+            final ProblemDescriptor problemDescriptor = createProblemDescriptor(file, manager, "Please set 'Cppcheck Path' in 'Cppcheck Configuration'.");
             return new ProblemDescriptor[]{problemDescriptor};
         }
 
         final File cppcheckPathFile = new File(cppcheckPath);
         if (!cppcheckPathFile.exists()) {
-            final ProblemDescriptor problemDescriptor = manager.createProblemDescriptor(
-                    file,
-                    (TextRange)null,
-                    "Configured 'Cppcheck Path' in the 'Cppcheck Configuration' does not exist: " + cppcheckPathFile.getAbsolutePath(),
-                    ProblemHighlightType.GENERIC_ERROR,
-                    true);
+            final ProblemDescriptor problemDescriptor = createProblemDescriptor(file, manager, "Configured 'Cppcheck Path' in 'Cppcheck Configuration' does not exist: " + cppcheckPathFile.getAbsolutePath());
             return new ProblemDescriptor[]{problemDescriptor};
         }
 
@@ -91,12 +92,7 @@ class CppcheckInspection extends LocalInspectionTool {
             CppcheckNotification.send("execution failed for " + vFile.getCanonicalPath(),
                     ex.getClass().getSimpleName() + ": " + ex.getMessage(),
                     NotificationType.ERROR);
-            final ProblemDescriptor problemDescriptor = manager.createProblemDescriptor(
-                    file,
-                    (TextRange)null,
-                    "Cppcheck execution failed: " + ex.getClass().getSimpleName() + ": " + ex.getMessage().split("\n", 2)[0],
-                    ProblemHighlightType.GENERIC_ERROR,
-                    true);
+            final ProblemDescriptor problemDescriptor = createProblemDescriptor(file, manager, "Cppcheck execution failed: " + ex.getClass().getSimpleName() + ": " + ex.getMessage().split("\n", 2)[0]);
             descriptors = new ProblemDescriptor[]{problemDescriptor};
         } finally {
             if (tempFile != null) {


### PR DESCRIPTION
Currently if the `Cppcheck Path` is not configured it will just show an extreme hard-to-spot message in the status bar.

![image](https://user-images.githubusercontent.com/242857/228506900-8f9c0704-e7c6-466b-8da1-4f289559b750.png)

That message may also be overwritten at any point so it is very unlikely any user will ever recognize it. It also isn't listed in the notifications.

So report it as a global inspection error so it is visible to the user. This is similar to what I did in #81:

![image](https://user-images.githubusercontent.com/242857/228508365-d6c06a03-2e82-4dbf-9b32-86bd63b8ee8a.png)

It will now also report errors in case the file cannot be found instead of showing an execution failure:

![image](https://user-images.githubusercontent.com/242857/228508173-b25ee72d-b80f-4179-8133-d712c90156d6.png)