### PR TITLE
display all available details for findings in tooltip - fixes #75

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Deployment.
 - Display `Cppcheck Path` configuration errors as global inspection errors instead of using a (hard to spot) status bar message.
 - Display global inspection error and omit the option if the configured `MISRA Addon JSON` does not exist.
 - Made plugin verbose level configurable via settings.
+- Display all available details for findings in tooltip.
 
 ### 1.6.2 - 2022-01-25
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -28,6 +28,7 @@
     - Display `Cppcheck Path` configuration errors as global inspection errors instead of using a (hard to spot) status bar message.
     - Display global inspection error and omit the option if the configured `MISRA Addon JSON` does not exist.
     - Made plugin verbose level configurable via settings.
+    - Display all available details for findings in tooltip.
     ]]>
   </change-notes>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -23,11 +23,11 @@
     ]]></description>
 
   <change-notes><![CDATA[
-    - Added `Show Cppcheck XML Output` action to show the latest XML output.
-    - Report execution errors as global inspection errors.
-    - Display `Cppcheck Path` configuration errors as global inspection errors instead of using a (hard to spot) status bar message.
-    - Display global inspection error and omit the option if the configured `MISRA Addon JSON` does not exist.
-    - Made plugin verbose level configurable via settings.
+    - Added `Show Cppcheck XML Output` action to show the latest XML output.<br/>
+    - Report execution errors as global inspection errors.<br/>
+    - Display `Cppcheck Path` configuration errors as global inspection errors instead of using a (hard to spot) status bar message.<br/>
+    - Display global inspection error and omit the option if the configured `MISRA Addon JSON` does not exist.<br/>
+    - Made plugin verbose level configurable via settings.<br/>
     - Display all available details for findings in tooltip.
     ]]>
   </change-notes>

--- a/src/com/github/johnthagen/cppcheck/CppCheckInspectionImpl.java
+++ b/src/com/github/johnthagen/cppcheck/CppCheckInspectionImpl.java
@@ -62,6 +62,34 @@ class CppCheckInspectionImpl {
     private final int verboseLevel;
     private static final String INCONCLUSIVE_TEXT = ":inconclusive";
 
+    static class Location
+    {
+        Location(@NotNull final Node location) {
+            final NamedNodeMap locationAttributes = location.getAttributes();
+            file = new File(locationAttributes.getNamedItem("file").getNodeValue()).getName();
+            line = Integer.parseInt(locationAttributes.getNamedItem("line").getNodeValue());
+            final Node columnAttr = locationAttributes.getNamedItem("column");
+            // the "column" attribute was added in Cppcheck 1.89
+            if (columnAttr != null) {
+                column = Integer.parseInt(columnAttr.getNodeValue());
+            }
+            else {
+                column = -1;
+            }
+            final Node infoAttr = locationAttributes.getNamedItem("info");
+            if (infoAttr != null) {
+                info = infoAttr.getNodeValue();
+            } else {
+                info = null;
+            }
+        }
+
+        final String file;
+        final int line;
+        final int column;
+        final String info;
+    }
+
     @NotNull
     public List<ProblemDescriptor> parseOutput(@NotNull final PsiFile psiFile,
                                                @NotNull final InspectionManager manager,
@@ -141,14 +169,14 @@ class CppCheckInspectionImpl {
             final Node inconclusiveNode = attributes.getNamedItem("inconclusive");
             final boolean inconclusive = inconclusiveNode != null && inconclusiveNode.getNodeValue().equals("true");
 
-            Node location = null;
+            Location location = null;
 
             // look for the first "location" child name
             final NodeList children = error.getChildNodes();
             for (int j = 0; j < children.getLength(); ++j) {
                 final Node child = children.item(j);
                 if (child.getNodeName().equals("location")) {
-                    location = child;
+                    location = new Location(child);
                     break;
                 }
             }
@@ -161,16 +189,10 @@ class CppCheckInspectionImpl {
                 continue;
             }
 
-            final NamedNodeMap locationAttributes = location.getAttributes();
-            final String fileName = new File(locationAttributes.getNamedItem("file").getNodeValue()).getName();
-            int lineNumber = Integer.parseInt(locationAttributes.getNamedItem("line").getNodeValue());
-            final Node columnAttr = locationAttributes.getNamedItem("column");
+            final String fileName = location.file;
+            int lineNumber = location.line;
             // TODO: use in ProblemDescriptor
-            int column = -1;
-            // the "column" attribute was added in Cppcheck 1.89
-            if (columnAttr != null) {
-                column = Integer.parseInt(columnAttr.getNodeValue());
-            }
+            final int column = location.column;
 
             if (verboseLevel >= 4) {
                 CppcheckNotification.send(id + " for " + vFile.getCanonicalPath(),


### PR DESCRIPTION
This will parse all available `locations` and display the `info` elements as additional details in the tooltip of a finding.

See https://github.com/johnthagen/clion-cppcheck/issues/75#issuecomment-1490624939 for a preview.