### PR TITLE
apply the provided column information to the highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Deployment.
 - Display global inspection error and omit the option if the configured `MISRA Addon JSON` does not exist.
 - Made plugin verbose level configurable via settings.
 - Display all available details for findings in tooltip.
+- Apply the provided column information to the highlighting.
 
 ### 1.6.2 - 2022-01-25
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -28,7 +28,8 @@
     - Display `Cppcheck Path` configuration errors as global inspection errors instead of using a (hard to spot) status bar message.<br/>
     - Display global inspection error and omit the option if the configured `MISRA Addon JSON` does not exist.<br/>
     - Made plugin verbose level configurable via settings.<br/>
-    - Display all available details for findings in tooltip.
+    - Display all available details for findings in tooltip.<br/>
+    - Apply the provided column information to the highlighting.
     ]]>
   </change-notes>
 

--- a/src/com/github/johnthagen/cppcheck/CppCheckInspectionImpl.java
+++ b/src/com/github/johnthagen/cppcheck/CppCheckInspectionImpl.java
@@ -190,7 +190,6 @@ class CppCheckInspectionImpl {
 
             final String fileName = locations.get(0).file;
             int lineNumber = locations.get(0).line;
-            // TODO: use in ProblemDescriptor
             final int column = locations.get(0).column;
 
             if (verboseLevel >= 4) {
@@ -214,10 +213,10 @@ class CppCheckInspectionImpl {
                 continue;
             }
 
-            // Document counts lines starting at 0, rather than 1 like in cppcheck.
+            // Document counts lines and columns starting at 0, rather than 1 like in cppcheck.
             lineNumber -= 1;
 
-            final int lineStartOffset = DocumentUtil.getFirstNonSpaceCharOffset(document, lineNumber);
+            final int lineStartOffset = (column == -1) ? DocumentUtil.getFirstNonSpaceCharOffset(document, lineNumber) : (document.getLineStartOffset(lineNumber) + (column -1));
             final int lineEndOffset = document.getLineEndOffset(lineNumber);
 
             String details = "";


### PR DESCRIPTION
This applies the provided information from Cppcheck and improves the highlighting.

Example:
```xml
        <error id="returnDanglingLifetime" severity="error" msg="Returning pointer that will be invalid when returning." verbose="Returning pointer that will be invalid when returning." cwe="562" file0="C:/Users/Username/AppData/Local/Temp/FGuuaiWE_test.cpp">
            <location file="C:\Users\Username\AppData\Local\Temp\FGuuaiWE_test.cpp" line="5" column="9"/>
            <location file="C:\Users\Username\AppData\Local\Temp\FGuuaiWE_test.cpp" line="4" column="37" info="Pointer to container is created here."/>
        </error>
```

Before:

![image](https://user-images.githubusercontent.com/242857/234585874-117450ed-462e-46ce-ba8c-909d48b04833.png)

After:

![image](https://user-images.githubusercontent.com/242857/234587288-4bdd5c53-c7af-4234-87ba-2ec36c229527.png)